### PR TITLE
Read value of AllowTcpForwarding option

### DIFF
--- a/src/SshNet.TestTools.OpenSSH/SshdConfig.cs
+++ b/src/SshNet.TestTools.OpenSSH/SshdConfig.cs
@@ -356,7 +356,7 @@ namespace SshNet.TestTools.OpenSSH
                     sshdConfig.Protocol = value;
                     break;
                 case "AllowTcpForwarding":
-                    sshdConfig.AllowTcpForwarding = false;
+                    sshdConfig.AllowTcpForwarding = ToBool(value);
                     break;
                 case "KeyRegenerationInterval":
                 case "HostbasedAuthentication":


### PR DESCRIPTION
Read the value of the **AllowTcpForwarding** option from the sshd config.